### PR TITLE
Allow the main mysql host to be specified via config.

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -51,6 +51,8 @@ properties:
   cf_mysql.mysql.port:
     description: 'Port the mysql server should bind to'
     default: 3306
+  cf_mysql.mysql.advertise_host:
+    description: 'IP address used to reach mysql from other cluster members'
   cf_mysql.mysql.galera_port:
     description: 'Port which Galera Cluster uses for communication across nodes'
     default: 4567

--- a/jobs/mysql/templates/mariadb_ctl_config.yml.erb
+++ b/jobs/mysql/templates/mariadb_ctl_config.yml.erb
@@ -14,7 +14,6 @@ def discover_external_ip
      end
      network.ip
    end
-   network_ip = discover_external_ip
 %>
 
 <%
@@ -52,4 +51,4 @@ Manager:
   <% cluster_ips.each do |ip| %>
   - <%= ip %>
   <% end %>
-  MyIP: <%= network_ip %>
+  MyIP: <%= p('cf_mysql.mysql.advertise_host') || discover_external_ip %>

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -17,7 +17,6 @@
     end
     network.ip
   end
-  network_ip = discover_external_ip
 
   def use_syslog
     returnvalue = false
@@ -45,7 +44,7 @@ nice      = 0
 wsrep_provider=/var/vcap/packages/mariadb/lib/plugin/libgalera_smm.so
 wsrep_provider_options="gcache.size=<%= p('cf_mysql.mysql.gcache_size') %>M;pc.recovery=TRUE;pc.checksum=TRUE"
 wsrep_cluster_address="gcomm://<%= cluster_ips.join(",") %>"
-wsrep_node_address='<%= network_ip %>:<%= p('cf_mysql.mysql.galera_port') %>'
+wsrep_node_address='<%= p('cf_mysql.mysql.advertise_host') || discover_external_ip %>:<%= p('cf_mysql.mysql.galera_port') %>'
 wsrep_node_name='<%= name %>/<%= index %>'
 wsrep_cluster_name='cf-mariadb-galera-cluster'
 wsrep_sst_method=xtrabackup-v2


### PR DESCRIPTION
Currently the mysql host is assumed to be the same as the default
network host. This change allows deploy-time selection of the
main mysql host for a cluster.
